### PR TITLE
build: release version 1.15.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout timefold-quickstarts
         uses: actions/checkout@v4
         with:
-          repository: TimefoldAI/timefold-quickstarts
+          repository: zepfred/timefold-quickstarts
           path: ./timefold-quickstarts
           ref: ${{ github.event.inputs.developmentBranch }}
           fetch-depth: 0 # Otherwise merge will fail on account of not having history.
@@ -108,10 +108,10 @@ jobs:
           git merge --squash $RELEASE_BRANCH_NAME
           git commit -m "build: release version ${{ github.event.inputs.javaVersion }}"
           git push origin $RELEASE_BRANCH_NAME-bump
-          git branch -D $RELEASE_BRANCH_NAME
           gh pr create --reviewer triceo --base ${{ github.event.inputs.stableBranch }} --head $RELEASE_BRANCH_NAME-bump --title "build: release version ${{ github.event.inputs.javaVersion }}" --body-file .github/workflows/release-pr-body.md
 
       - name: Put back the 999-SNAPSHOT version on the release branch
+        working-directory: ./timefold-quickstarts
         run: |
           git checkout $RELEASE_BRANCH_NAME
           export OLD_JAVA_VERSION="$(find . -name pom.xml -exec grep '<version.ai.timefold.solver>' {} \;|tail -n 1|cut -d\> -f1 --complement|cut -d\< -f1)"
@@ -121,3 +121,29 @@ jobs:
           .github/scripts/change_versions.sh
           git commit -am "build: move back to version $NEW_VERSION"
           git push origin $RELEASE_BRANCH_NAME
+
+      - name: Update release branch
+        working-directory: ./timefold-quickstarts
+        shell: bash
+        run: |
+          tag=${{ github.ref }}
+          tag_version=${tag##*/}
+          version=${tag_version%.*}
+          version="${version:1}.x"
+          echo $version
+          exists="$(git branch -a | grep -w $version || true)"
+          echo "branch $exists"
+          if [ -n "$exists" ]; then
+            git config user.name "Timefold Release Bot"
+            git config user.email "release@timefold.ai"
+            git checkout $RELEASE_BRANCH_NAME
+            git checkout $version
+            git merge -Xtheirs --no-edit --squash -m "build: release version $tag_version" $RELEASE_BRANCH_NAME
+            git push origin $version
+            git push -d origin $RELEASE_BRANCH_NAME
+          else
+            git checkout $RELEASE_BRANCH_NAME
+            git branch -m $RELEASE_BRANCH_NAME $version
+            git push origin -u $version
+            git push -d origin $RELEASE_BRANCH_NAME
+          fi


### PR DESCRIPTION
At this point, the release of _Timefold Quickstarts_ is ready to be published.

- Release branch has been created.
- Git tag has been published.

To finish the release of _Timefold Quickstarts_,
review and merge this PR to update the `stable` branch with new code.
Afterward, delete the branch that this PR is based on.
(Typically a button appears on this page once the PR is merged.)